### PR TITLE
needed to clear broswer cache for saved login info

### DIFF
--- a/app/controllers/NavCtrl.js
+++ b/app/controllers/NavCtrl.js
@@ -24,6 +24,7 @@ app.controller("NavCtrl", function($scope, $location, AuthFactory, DataFactory, 
         LocationFactory.newCity($scope.newLocation.city);
         $("#locationModal").modal('close');
         $location.url('/showslist');
+        $scope.newLocation.city = "";
     };
 
     $scope.reloadPage = function(){
@@ -40,7 +41,9 @@ app.controller("NavCtrl", function($scope, $location, AuthFactory, DataFactory, 
         $timeout(()=>{
             LocationFactory.getCityByCoords($scope.currentLocation.lat, $scope.currentLocation.long)
             .then(()=>{
+                $("#locationModal").modal('close');
                 $location.url('/showslist');
+                $route.reload();
             });
         }, 5000);
     };

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -4,8 +4,8 @@
         <div class="nav-wrapper container-fluid">
           <a href="#!/showslist" class="brand-logo">Shows Around</a>
           <ul id="nav-mobile" class="right hide-on-med-and-down">
-            <li><a data-target='locationModal' modal>Location</a></li>
-            <li><a ng-href="#!/trackedshows">Tracked Shows</a></li>
+            <li><a data-target='locationModal' ng-show="isLoggedIn" modal>Location</a></li>
+            <li><a ng-href="#!/trackedshows" ng-show="isLoggedIn">Tracked Shows</a></li>
             <li><a href="#" title="" ng-show="!isLoggedIn">Login</a></li>
             <li><a href="#" ng-controller="AuthCtrl" ng-click="logout()" ng-show="isLoggedIn">Logout</a></li>
           </ul>
@@ -26,7 +26,7 @@
 
       </div> <!-- end modal-content -->
       <div class="modal-footer">
-          <a href="#!" class=" modal-action modal-close waves-effect waves-green btn-flat">Cancel</a>
+          <a href="" class=" modal-action modal-close waves-effect waves-green btn-flat">Cancel</a>
       </div>
   </div>
   <!-- END MODAL -->


### PR DESCRIPTION
Login with facebook was being screwy - turns out I had kept my login info saved in the broswer from forever ago. 

Also the window to login to spotify always asks to verify login. I might take this out once everything is up and running as, realistically, a user will be logging in from their own machine and public machines will have browser info wiped at end of evert session. 

to do this go into the angular-spotify.min.js file in the node modules and remove `show_dialog: true`at the bottom of the file (~4 lines from the bottom inside the 'params' object)